### PR TITLE
Makes tcp-proxy better at handling SIGINT/SIGTERM

### DIFF
--- a/tcp-proxy.sh
+++ b/tcp-proxy.sh
@@ -7,8 +7,34 @@ fi
 
 HOST="$1"
 PORT="$2"
-
 LISTEN_PORT=${LISTEN_PORT:-${PORT}}
+pid=0
 
+term_handler() {
+  if [ $pid -ne 0 ]; then
+    kill -SIGTERM "$pid"
+    wait "$pid"
+  fi
+  exit 143; # 128 + 15 -- SIGTERM
+}
+
+int_handler() {
+  if [ $pid -ne 0 ]; then
+    kill -SIGINT "$pid"
+    wait "$pid"
+  fi
+  exit 130; # 128 + 2 -- SIGINT
+}
+
+trap 'kill ${!}; term_handler' SIGTERM
+trap 'kill ${!}; int_handler' SIGINT
 echo "relay TCP/IP connections on :${LISTEN_PORT} to ${HOST}:${PORT}"
-socat TCP-LISTEN:${LISTEN_PORT},fork,reuseaddr TCP:${HOST}:${PORT}
+
+socat TCP-LISTEN:${LISTEN_PORT},fork,reuseaddr TCP:${HOST}:${PORT} &
+pid="$!"
+
+# wait forever
+while true
+do
+  tail -f /dev/null & wait ${!}
+done


### PR DESCRIPTION
This change makes the tcp-proxy script a bit smarter when it comes to handling SIGINT/SIGTERM signals and it isn't currently in the foreground in an interactive tty. The most common cause of this scenario is spawning multiple containers using `docker run` while managing their concurrency with something like a tmux session.

In addition to `trap` handlers, we background the `socat` call and collect its PID.